### PR TITLE
Link prominently to vibecto.ai

### DIFF
--- a/src/_includes/components/header.njk
+++ b/src/_includes/components/header.njk
@@ -11,7 +11,7 @@
                 <a href="/services" class="hover:text-accent transition duration-300">Services</a>
             </li>
             <li class="hidden md:block">
-                <a href="/framework" class="hover:text-accent transition duration-300">Framework</a>
+                <a href="https://vibecto.ai" target="_blank" rel="noopener noreferrer" class="hover:text-accent transition duration-300">vibecto.ai</a>
             </li>
             <li class="hidden md:block">
                 <a href="/posts" class="hover:text-accent transition duration-300">The Journey</a>

--- a/src/index.njk
+++ b/src/index.njk
@@ -138,6 +138,39 @@ image: /assets/images/home-og-image.png
   </div>
 </section>
 
+<section class="py-16 px-4 bg-gradient-to-r from-blue-50 to-indigo-50">
+  <div class="container mx-auto max-w-4xl text-center">
+    <h2 class="text-4xl font-serif font-bold text-primary mb-6">
+      Need AI-Forward Help?
+    </h2>
+    <p class="text-xl text-gray-700 mb-8">
+      Check out <strong>vibecto.ai</strong> - our sister brand focused on AI-powered solutions for modern businesses. Get cutting-edge AI implementation, strategy, and training to accelerate your growth.
+    </p>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+      <div class="bg-white p-6 rounded-lg shadow-md">
+        <h3 class="text-lg font-bold text-primary mb-2">AI Strategy</h3>
+        <p class="text-gray-600">Transform your business with tailored AI implementation roadmaps</p>
+      </div>
+      <div class="bg-white p-6 rounded-lg shadow-md">
+        <h3 class="text-lg font-bold text-primary mb-2">Custom AI Solutions</h3>
+        <p class="text-gray-600">Build intelligent systems that solve your specific challenges</p>
+      </div>
+      <div class="bg-white p-6 rounded-lg shadow-md">
+        <h3 class="text-lg font-bold text-primary mb-2">AI Training</h3>
+        <p class="text-gray-600">Upskill your team with practical AI tools and methodologies</p>
+      </div>
+    </div>
+    <a
+      href="https://vibecto.ai"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="inline-block bg-blue-600 text-white px-8 py-3 rounded-full hover:bg-blue-700 transition duration-300 text-lg font-medium"
+    >
+      Explore vibecto.ai →
+    </a>
+  </div>
+</section>
+
 {% include "components/svg-divider.njk" %}
 {% set emailSignup = {
   heading: "Stories from The Journey ",

--- a/src/index.njk
+++ b/src/index.njk
@@ -144,20 +144,20 @@ image: /assets/images/home-og-image.png
       Need AI-Forward Help?
     </h2>
     <p class="text-xl text-gray-700 mb-8">
-      Check out <strong>vibecto.ai</strong> - our sister brand focused on AI-powered solutions for modern businesses. Get cutting-edge AI implementation, strategy, and training to accelerate your growth.
+      Check out <strong>vibecto.ai</strong> - our sister brand focused on providing human help to build with AI
     </p>
     <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
       <div class="bg-white p-6 rounded-lg shadow-md">
-        <h3 class="text-lg font-bold text-primary mb-2">AI Strategy</h3>
-        <p class="text-gray-600">Transform your business with tailored AI implementation roadmaps</p>
+        <h3 class="text-lg font-bold text-primary mb-2">Transformation</h3>
+        <p class="text-gray-600">Get expert, hands-on help to implement the latest AI tooling to upskill your team and accelerate your roadmap</p>
       </div>
       <div class="bg-white p-6 rounded-lg shadow-md">
-        <h3 class="text-lg font-bold text-primary mb-2">Custom AI Solutions</h3>
-        <p class="text-gray-600">Build intelligent systems that solve your specific challenges</p>
+        <h3 class="text-lg font-bold text-primary mb-2">Scaling Vibe Code</h3>
+        <p class="text-gray-600">Help to confidently scale vibe coded prototypes with traction into products for external and internal users/</p>
       </div>
       <div class="bg-white p-6 rounded-lg shadow-md">
-        <h3 class="text-lg font-bold text-primary mb-2">AI Training</h3>
-        <p class="text-gray-600">Upskill your team with practical AI tools and methodologies</p>
+        <h3 class="text-lg font-bold text-primary mb-2">Prototype Acceleration</h3>
+        <p class="text-gray-600">Get your vibe coding jumpstart with a prototype and guidance from an expert 0 to 1 builder</p>
       </div>
     </div>
     <a
@@ -166,7 +166,7 @@ image: /assets/images/home-og-image.png
       rel="noopener noreferrer"
       class="inline-block bg-blue-600 text-white px-8 py-3 rounded-full hover:bg-blue-700 transition duration-300 text-lg font-medium"
     >
-      Explore vibecto.ai →
+      Explore VibeCTO.ai →
     </a>
   </div>
 </section>


### PR DESCRIPTION
Replaces the framework nav item with a link to vibecto.ai and creates a prominent section on the home page highlighting vibecto.ai's AI-forward services.

Closes #26

Generated with [Claude Code](https://claude.ai/code)